### PR TITLE
Add Token-based permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ DRF Utils only supports Python 3. It has been tested with Python 3.4.
 
 Run tests with:
 
-    DJANGO_SETTINGS_MODULE=drfutils.tests.settings python -m unittest discover
+    DJANGO_SETTINGS_MODULE=drfutils.tests.settings django-admin test

--- a/drfutils/admin.py
+++ b/drfutils/admin.py
@@ -1,0 +1,9 @@
+from django.contrib import admin
+
+from .models import Token
+
+
+class TokenAdmin(admin.ModelAdmin):
+    list_display = ('key', 'label')
+
+admin.site.register(Token, TokenAdmin)

--- a/drfutils/conf.py
+++ b/drfutils/conf.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+TOKEN_HEADER = getattr(
+    settings, 'DRF_UTILS_SERVICE_TOKEN_HEADER', 'X-Service-Access-Token'
+)

--- a/drfutils/models.py
+++ b/drfutils/models.py
@@ -1,0 +1,29 @@
+import uuid
+
+from django.db import models
+
+
+class Token(models.Model):
+    """
+    A token that can be used for API authentication and authorisation.
+
+    Initially intended to use to authorise an API client, this may later
+    be extended to support user or team tokens.
+
+    """
+    key = models.CharField(max_length=50, primary_key=True, editable=False)
+    label = models.CharField(
+        max_length=200,
+        help_text="""
+        A label to distinguish between tokens.
+        May be e.g. the provider/client name.
+        """
+    )
+
+    def __unicode__(self):
+        return self.key
+
+    def save(self, *args, **kwargs):
+        if not self.key:
+            self.key = str(uuid.uuid4())
+        super(Token, self).save(*args, **kwargs)

--- a/drfutils/permissions.py
+++ b/drfutils/permissions.py
@@ -2,11 +2,11 @@ import logging
 
 from rest_framework import permissions
 
+from .conf import TOKEN_HEADER
 from .models import Token
 
 
-LOGGER = logging.getLogger('ployst.api')
-TOKEN_HEADER = 'X-Ployst-Access-Token'
+LOGGER = logging.getLogger('drfutils.permissions')
 HTTP_TOKEN_LOOKUP = "HTTP_" + TOKEN_HEADER.replace('-', '_').upper()
 
 
@@ -15,7 +15,7 @@ def contains_valid_token(request):
     Check that the request contains a registered token.
 
     The request must include a header or querystring argument
-    `X-Ployst-Access-Token` to match a token for a registered client.
+    `TOKEN_HEADER` to match a token for a registered client.
 
     """
     access_token = request.META.get(HTTP_TOKEN_LOOKUP)

--- a/drfutils/permissions.py
+++ b/drfutils/permissions.py
@@ -1,0 +1,124 @@
+import logging
+
+from rest_framework import permissions
+
+from .models import Token
+
+
+LOGGER = logging.getLogger('ployst.api')
+TOKEN_HEADER = 'X-Ployst-Access-Token'
+HTTP_TOKEN_LOOKUP = "HTTP_" + TOKEN_HEADER.replace('-', '_').upper()
+
+
+def contains_valid_token(request):
+    """
+    Check that the request contains a registered token.
+
+    The request must include a header or querystring argument
+    `X-Ployst-Access-Token` to match a token for a registered client.
+
+    """
+    access_token = request.META.get(HTTP_TOKEN_LOOKUP)
+
+    if access_token is None:
+        access_token = request.GET.get(TOKEN_HEADER)
+
+    if access_token is not None:
+        token_matched = Token.objects.filter(key=access_token).exists()
+        if not token_matched:
+            LOGGER.error(
+                "Token provided ({0}) "
+                "didn't match any existing token".format(access_token)
+            )
+        return token_matched
+
+    return False
+
+
+class ClientTokenPermission(permissions.BasePermission):
+    """
+    A special permissions checker based on tokens.
+
+    """
+    def has_permission(self, request, view):
+        """
+        Will only allow access if token matches that of a registered client.
+
+        A token may be included as a proprietary HTTP header or as part of
+        the query string (this is useful when clients cannot set HTTP headers,
+        e.g. when testing with a browser).
+
+        This security check is intentionally simplistic for now. Later on we
+        may want to match originating host/domain and token.
+        """
+        return contains_valid_token(request)
+
+    def has_object_permission(self, request, view, obj):
+        """
+        Permissions to objects will be granted if token check was successful
+        """
+        return self.has_permission(request, view)
+
+
+class IsAuthenticated(permissions.IsAuthenticated):
+    """
+    Allows access only to authenticated users.
+
+    This is intended as a replacement for built-in IsAuthenticated, that
+    returns True on has_object_permission regardless of authenticated user,
+    making it unsuitable for use with the AnyPermission logical-OR chaining.
+
+    """
+    def has_object_permission(self, request, view, obj):
+        return self.has_permission(request, view)
+
+
+class AnyPermissions(permissions.BasePermission):
+    """
+    DRF permission chaining using an 'OR' logic
+
+    In standard DRF, when you specify multiple permissions classes, they all
+    have to allow access for the permission to work ('AND'). This class allows
+    chaining alternative permission checks (as in logged in users versus
+    token-based permission.
+
+    Permissions are set by defining an attribute in the view named
+    'any_permission_classes'
+
+    """
+    def get_permissions(self, view):
+        """
+        Get all of the permissions classes that are associated with the view.
+        """
+
+        return getattr(view, "any_permission_classes", [])
+
+    def has_permission(self, request, view):
+        """
+        Check the permissions on the view.
+        """
+
+        permissions = self.get_permissions(view)
+
+        for perm_class in permissions:
+            permission = perm_class()
+
+            if permission.has_permission(request, view):
+                return True
+
+        return not permissions
+
+    def has_object_permission(self, request, view, obj):
+        """
+        Check the object permissions on the view.
+        """
+
+        permissions = self.get_permissions(view)
+
+        for perm_class in permissions:
+            permission = perm_class()
+
+            if permission.has_object_permission(request, view, obj):
+                return True
+
+        return not permissions

--- a/drfutils/tests/mixins.py
+++ b/drfutils/tests/mixins.py
@@ -1,0 +1,22 @@
+from rest_framework.test import APIRequestFactory
+
+from ..models import Token
+from ..permissions import HTTP_TOKEN_LOOKUP
+
+
+class CoreApiClientTestMixin(object):
+    """
+    Mixin that creates a token to allow unlimited API access.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.token = Token.objects.create()
+        cls.request_factory = APIRequestFactory()
+
+    @classmethod
+    def tearDownClass(cls):
+        Token.objects.all().delete()
+
+    def get_token_headers(self):
+        return {HTTP_TOKEN_LOOKUP: self.token.key}

--- a/drfutils/tests/settings.py
+++ b/drfutils/tests/settings.py
@@ -7,4 +7,12 @@ SECRET_KEY = os.environ.get(
 
 INSTALLED_APPS = (
     'rest_framework',
+    'drfutils',
 )
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'drfutil-tests.db',
+    }
+}

--- a/drfutils/tests/test_fields.py
+++ b/drfutils/tests/test_fields.py
@@ -20,7 +20,7 @@ class TestGravatarField(TestCase):
 
         self.assertEqual(
             serializer.data['gravatar'],
-            'http://gravatar.com/avatar/1c3ed1dc72e643886e597e2d07700b3c'
+            '//gravatar.com/avatar/1c3ed1dc72e643886e597e2d07700b3c'
         )
 
 

--- a/drfutils/tests/test_token_permissions.py
+++ b/drfutils/tests/test_token_permissions.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+from ..permissions import ClientTokenPermission, TOKEN_HEADER
+from .mixins import CoreApiClientTestMixin
+
+
+class TestTokenPermissions(CoreApiClientTestMixin, TestCase):
+
+    def test_no_token_no_permission(self):
+        request = self.request_factory.get('/')
+        permissions = ClientTokenPermission()
+        self.assertFalse(permissions.has_permission(request, None))
+
+    def test_valid_token_in_url_has_permission(self):
+        request = self.request_factory.get('/', {TOKEN_HEADER: self.token.key})
+        permissions = ClientTokenPermission()
+        self.assertTrue(permissions.has_permission(request, None))
+
+    def test_valid_token_in_header__has_permission(self):
+        request = self.request_factory.get('/', **self.get_token_headers())
+        permissions = ClientTokenPermission()
+        self.assertTrue(permissions.has_permission(request, None))

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup
 import os
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 
 
 DIR = os.path.dirname(__file__)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-Django==1.8.7
+Django==1.9.2
 djangorestframework==3.2.3       # REST API layer
 
 coverage


### PR DESCRIPTION
Adds token-based permissions. Borrowed from ployst1.

Tokens are used to authenticate API client applications. Permissions are not fine-grained. They are intended to be used by satellite services to your API, by default with full access to objects.

@alexcouper please review
