### PR TITLE
Add SerializerBuilder

### DIFF
--- a/drfutils/serializers.py
+++ b/drfutils/serializers.py
@@ -89,9 +89,9 @@ class ExpandableFieldsSerializerMixin(object):
                     )
 
 
-def SerializerBuilder(serializer_class, fields):
+def SubSerializer(serializer_class, fields):
     serializer_class = type(
-        'CustomSerializer',
+        'Sub{}'.format(serializer_class.__name__),
         (LimitedFieldsSerializerMixin, serializer_class),
         {}
     )

--- a/drfutils/tests/test_serializers.py
+++ b/drfutils/tests/test_serializers.py
@@ -6,7 +6,7 @@ from rest_framework import fields, serializers
 from ..serializers import (
     DynamicFieldsSerializerMixin,
     ExpandableFieldsSerializerMixin,
-    SerializerBuilder,
+    SubSerializer,
 )
 
 
@@ -119,12 +119,16 @@ class TestDynamicFieldsSerializer(TestCase):
 class TestSerializerBuilder(TestCase):
 
     def test_only_returns_requested_fields(self):
+        serializer_class = SubSerializer(CreatorSerializer, ('nickname',))
+        self.assertDictEqual(serializer_class.name, 'SubCreatorSerializer')
+
+    def test_only_returns_requested_fields(self):
         class Thing(object):
             name = 'Only James'
             nickname = 'catnip'
 
         jim = Thing()
-        serializer_class = SerializerBuilder(CreatorSerializer, ('nickname',))
+        serializer_class = SubSerializer(CreatorSerializer, ('nickname',))
         serializer = serializer_class(jim)
 
         self.assertDictEqual(serializer.data, {'nickname': 'catnip'})


### PR DESCRIPTION
This reduces the need of creating multiple serializer classes only to have subsets of fields.

Creating a _custom_ serializer with a determined subset of fields is now as easy as:

``` python
class SubscriptionSerializer(serializers.ModelSerializer):
    user = SubSerializer(
        UserIdentitySerializer, ('url', 'username', 'first_name', 'last_name')
    )(source='context.user')
```
