### PR TITLE
Ensure subserializers don't get mixed up

### DIFF
--- a/drfutils/serializers.py
+++ b/drfutils/serializers.py
@@ -89,11 +89,15 @@ class ExpandableFieldsSerializerMixin(object):
                     )
 
 
-def SubSerializer(serializer_class, fields):
-    serializer_class = type(
-        'Sub{}'.format(serializer_class.__name__),
-        (LimitedFieldsSerializerMixin, serializer_class),
-        {}
+def SubSerializer(original_serializer_class, fields):
+    new_meta = type(
+        'Meta',
+        (original_serializer_class.Meta,),
+        {'only_fields': fields}
     )
-    serializer_class.Meta.only_fields = fields
+    serializer_class = type(
+        'Sub{}'.format(original_serializer_class.__name__),
+        (LimitedFieldsSerializerMixin, original_serializer_class),
+        {'Meta': new_meta}
+    )
     return serializer_class

--- a/drfutils/tests/test_serializers.py
+++ b/drfutils/tests/test_serializers.py
@@ -116,11 +116,11 @@ class TestDynamicFieldsSerializer(TestCase):
         )
 
 
-class TestSerializerBuilder(TestCase):
+class TestSubSerializer(TestCase):
 
-    def test_only_returns_requested_fields(self):
+    def test_subserializer_name(self):
         serializer_class = SubSerializer(CreatorSerializer, ('nickname',))
-        self.assertDictEqual(serializer_class.name, 'SubCreatorSerializer')
+        self.assertEqual(serializer_class.__name__, 'SubCreatorSerializer')
 
     def test_only_returns_requested_fields(self):
         class Thing(object):
@@ -132,3 +132,18 @@ class TestSerializerBuilder(TestCase):
         serializer = serializer_class(jim)
 
         self.assertDictEqual(serializer.data, {'nickname': 'catnip'})
+
+    def test_subserializers_dont_get_mixed_up(self):
+        class Thing(object):
+            name = 'Only James'
+            nickname = 'catnip'
+
+        jim = Thing()
+        NicknameSerializer = SubSerializer(CreatorSerializer, ('nickname',))
+        NameSerializer = SubSerializer(CreatorSerializer, ('name',))
+
+        nickname_serializer = NicknameSerializer(jim)
+        name_serializer = NameSerializer(jim)
+
+        self.assertDictEqual(nickname_serializer.data, {'nickname': 'catnip'})
+        self.assertDictEqual(name_serializer.data, {'name': 'Only James'})


### PR DESCRIPTION
Multiple subserializers of the same base serializer were overriding their `only_fields` values.

Found while working on https://github.com/ployst/ployst/pull/122/files#r61100936
